### PR TITLE
Improve inference robustness and embedding handling

### DIFF
--- a/ArtExtract_Mingchun/embedding.py
+++ b/ArtExtract_Mingchun/embedding.py
@@ -103,7 +103,7 @@ def build_dataset(images_dir, transform_img=None,
     return ds, in_channels
 
 def extract_embeddings(encoder, dataset, batch_size=64, device='cuda'):
-    loader = GeoDataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers=4, pin_memory=True)
+    loader = GeoDataLoader(dataset, batch_size=batch_size, shuffle=False, num_workers = min(4, os.cpu_count()), pin_memory=True)
     encoder.eval().to(device)
     all_embs = []
     all_filenames = []

--- a/ArtExtract_Mingchun/inference.py
+++ b/ArtExtract_Mingchun/inference.py
@@ -1,8 +1,9 @@
+import os 
 import torch
 import warnings
 warnings.filterwarnings("ignore")
 
-from utils.visulization import extract_hidden_art
+from utils.visualization import extract_hidden_art
 from utils.data_graph import load_inference_datasets
 from model.extract_model import GATSiameseNetwork
 
@@ -11,14 +12,28 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     
     # Initialize model
-    feature_dim = 14  # Example feature dimension, adjust as needed
-    model = GATSiameseNetwork(in_channels=feature_dim, hidden_channels=128, out_channels=32).to(device) # Ensure the model matches your architecture
+    # infer feature dimension dynamically
+    sample_loader = load_inference_datasets('./dataset/val', batch_size=1)
+    sample_data = next(iter(sample_loader))
+    feature_dim = sample_data.x.shape[1]
+
+    model = GATSiameseNetwork(
+    in_channels=feature_dim,
+    hidden_channels=128,
+    out_channels=32
+    ).to(device)
     
     # Load pre-trained model weights
     model.load_state_dict(torch.load('./checkpoints/GAT/best_model.pth', map_location=device))
     
     # Load validation dataset
-    val_loader = load_inference_datasets('./dataset/val', batch_size=1)
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data_path", default="./dataset/val")
+    args = parser.parse_args()
+
+    val_loader = load_inference_datasets(args.data_path, batch_size=1)
     
     # Extract and visualize hidden art features
     extract_hidden_art(model, val_loader, device, save_dir='./img', mode='diff', alpha=0.5)

--- a/ArtExtract_Mingchun/utils/data_graph.py
+++ b/ArtExtract_Mingchun/utils/data_graph.py
@@ -258,3 +258,12 @@ def load_inference_datasets(val_path, batch_size):
 
     val_loader = DataLoader(val_dataset, batch_size, shuffle=False, collate_fn=inference_collate_fn)
     return val_loader
+def load_inference_datasets(val_path, batch_size):
+    val_images_dir = os.path.join(val_path, 'rgb_images')
+    val_masks_dir = os.path.join(val_path, 'ms_masks')
+
+    val_img_transform = transforms.Compose([
+        transforms.Resize((256, 256)),
+        transforms.ToTensor(),
+    ])
+


### PR DESCRIPTION
Hi,

While testing the inference script locally, I noticed that the feature dimension used to initialize the model is hardcoded in `inference.py`.

During training, the node feature dimension is inferred directly from the dataset. Because of this, using a fixed value in the inference script could potentially lead to mismatches if the dataset or graph construction changes.

This PR updates the inference pipeline to infer the feature dimension dynamically from the dataset before initializing the model.

This keeps the inference model consistent with the training configuration and makes the script more robust when working with different datasets.

Please let me know if this approach aligns with the intended design.