### PR TITLE
Add shape validation in psnr function in metrics.py

### DIFF
--- a/ArtExtract_Soyoung/utils/metrics.py
+++ b/ArtExtract_Soyoung/utils/metrics.py
@@ -24,6 +24,10 @@ class EvalMetrics(nn.Module):
         self.ssim_metric = ssim(data_range=1.0)
 
     def psnr(self, output, target):
+        if output.shape != target.shape:
+            raise ValueError(
+                f"Shape mismatch: output has shape {output.shape}, target has shape {target.shape}"
+            )
         # Compute MSE per channel
         mse_per_channel = torch.mean((target - output) ** 2, dim=[0, 2, 3])  # MSE per channel
         


### PR DESCRIPTION
Change made to ArtExtract_Soyoung/utils/metrics.py:

The psnr function computes element-wise differences between output and target with no check that their shapes match. A shape mismatch triggers a cryptic PyTorch broadcasting error with no indication of which tensors are involved or what their shapes are. Added a check at the top of the function that raises ValueError with the exact shapes of both tensors if they do not match.